### PR TITLE
Add Amphetamine to the mas install list

### DIFF
--- a/mas.sh
+++ b/mas.sh
@@ -4,8 +4,9 @@
 # with `mas search <name>`.
 
 apps=(
-  1423210932 # Flow - Focus & Pomodoro Timer
-  1440405750 # MusicHarbor
+  937984704 # Amphetamine: https://apps.apple.com/us/app/amphetamine/id937984704?mt=12
+  1423210932 # Flow - Focus & Pomodoro Timer: https://flowapp.info/
+  1440405750 # MusicHarbor: https://apps.apple.com/us/app/musicharbor-track-new-music/id1440405750
 )
 
 for app in "${apps[@]}"; do


### PR DESCRIPTION
## Background
[Amphetamine](https://apps.apple.com/us/app/amphetamine/id937984704?mt=12) has recently replaced [Caffeine](https://intelliscapesolutions.com/apps/caffeine) as my app of choice to prevent my Mac from going to sleep. As this can be installed via `mas`, this PR is to add the `mas` ID to the `mas` install list.

## What has changed
- adds Amphetamine's `mas` ID to `mas` install list
- adds links to the app in the comments