### PR TITLE
Add AmorphousDiskMark, Energize, and Hidden Bar to mas install list.

### DIFF
--- a/mas.sh
+++ b/mas.sh
@@ -4,8 +4,11 @@
 # with `mas search <name>`.
 
 apps=(
+  1168254295 # AmorphousDiskMark https://apps.apple.com/us/app/amorphousdiskmark/id1168254295?mt=12
   937984704 # Amphetamine: https://apps.apple.com/us/app/amphetamine/id937984704?mt=12
+  1643751440 # Energiza https://apps.apple.com/us/app/energiza-battery-monitor/id1643751440?mt=12
   1423210932 # Flow - Focus & Pomodoro Timer: https://flowapp.info/
+  1452452150 # Hidden Bar https://apps.apple.com/us/developer/dwarves-foundation/id1452452150
   1440405750 # MusicHarbor: https://apps.apple.com/us/app/musicharbor-track-new-music/id1440405750
 )
 


### PR DESCRIPTION
## Background
A few more apps have been added from the app store
- [AmorphousDiskMark](https://apps.apple.com/us/app/amorphousdiskmark/id1168254295?mt=12)
- [Energiza](https://apps.apple.com/us/app/energiza-battery-monitor/id1643751440?mt=12)
- [Hidden Bar](https://apps.apple.com/us/developer/dwarves-foundation/id1452452150)

## What's changed
- Added the three app's `mas` ID to `mas` install list