### PR TITLE
Remove Hyper and Fig from ZSH config

### DIFF
--- a/configs/.zshrc
+++ b/configs/.zshrc
@@ -124,7 +124,6 @@ alias pg-start="pg_ctl -D /usr/local/var/postgresql@11 start"
 alias pg-stop="pg_ctl -D /usr/local/var/postgresql@11 stop"
 alias pg-restart="pg_ctl -D /usr/local/var/postgresql@11 restart"
 alias vscode-ext="open ~/.vscode/extensions"
-alias hyper-config="code ~/.hyper.js"
 #alias capScrn="node /Users/yujinelson/Repositories/Magpul-m2/scripts/visual-testing.js"
 #alias ohmyzsh="code ~/.oh-my-zsh"
 
@@ -132,6 +131,3 @@ alias hyper-config="code ~/.hyper.js"
 # . /usr/local/etc/profile.d/z.sh
 export PATH="/usr/local/opt/postgresql@11/bin:$PATH"
 source /Users/yuji/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
-
-# Fig post block. Keep at the bottom of this file.
-[[ -f "$HOME/.fig/shell/zshrc.post.zsh" ]] && builtin source "$HOME/.fig/shell/zshrc.post.zsh"


### PR DESCRIPTION
## Background
This PR cleans up with `.zshrc` by removing lines relating to Hyper and Fig as both have been replaced by Warp

## What's changed
- Updated `.zshrc` by removing the `hyper-config` alias and the fig post block