### PR TITLE
Add lockscreen background install

### DIFF
--- a/brew.sh
+++ b/brew.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# import util functions
+[ -f ./utils.sh ] && . ./utils.sh
+
 set -o errexit
 set -o pipefail
 
@@ -14,86 +17,6 @@ Description:    Automate the installation of macOS
 Author:         JustAddCl
 Requirements:   Command Line Tools (CLT) for Xcode
 EOF
-}
-
-# Function to set terminal colors if supported.
-term_colors() {
-    if [[ -t 1 ]]; then
-        RED=$(printf '\033[31m')
-        GREEN=$(printf '\033[32m')
-        YELLOW=$(printf '\033[33m')
-        BLUE=$(printf '\033[34m')
-        MAGENTA=$(printf '\033[35m')
-        CYAN=$(printf '\033[36m')
-        BOLD=$(printf '\033[1m')
-        RESET=$(printf '\033[0m')
-    else
-        RED=""
-        GREEN=""
-        YELLOW=""
-        BLUE=""
-        MAGENTA=""
-        CYAN=""
-        BOLD=""
-        RESET=""
-    fi
-}
-
-# Function to output colored or bold terminal messages.
-# Usage examples: term_message "This is a default color and style message"
-#                 term_message nb "This is a default color bold message"
-#                 term_message rb "This is a red bold message"
-term_message() {
-    local set_color=""
-    local set_style=""
-    [[ -z "${2}" ]] && echo -ne "${1}" >&2 && return
-    [[ ${1:0:1} == "d" ]] && set_color=${RESET}
-    [[ ${1:0:1} == "r" ]] && set_color=${RED}
-    [[ ${1:0:1} == "g" ]] && set_color=${GREEN}
-    [[ ${1:0:1} == "y" ]] && set_color=${YELLOW}
-    [[ ${1:0:1} == "b" ]] && set_color=${BLUE}
-    [[ ${1:0:1} == "m" ]] && set_color=${MAGENTA}
-    [[ ${1:0:1} == "c" ]] && set_color=${CYAN}
-    [[ ${1:1:2} == "b" ]] && set_style=${BOLD}
-    echo -e "${set_color}${set_style}${2}${RESET}" >&2 && return
-}
-
-# Displays a box containing a dash and message
-task_start() {
-    echo -ne "[-] ${1}"
-}
-
-# Displays a box containing a green tick and optional message if required.
-task_done() {
-    echo -e "\r[\033[0;32m\xE2\x9C\x94\033[0m] ${1}"
-}
-
-# Displays a box containing a red cross and optional message if required.
-task_fail() {
-    echo -e "\r[\033[0;31m\xe2\x9c\x98\033[0m] ${1}"
-}
-
-# Function to pause script and check if the user wishes to continue.
-check_continue() {
-    local response
-    while true; do
-        read -r -p "Do you wish to continue (y/N)? " response
-        case "${response}" in
-        [yY][eE][sS] | [yY])
-            echo
-            break
-            ;;
-        *)
-            echo
-            exit
-            ;;
-        esac
-    done
-}
-
-# Function check command exists
-command_exists() {
-    command -v "${@}" >/dev/null 2>&1
 }
 
 check_xcode() {

--- a/install-configs.sh
+++ b/install-configs.sh
@@ -1,4 +1,58 @@
+#!/usr/bin/env bash
+# import util functions
+[ -f ./utils.sh ] && . ./utils.sh
+
 # Copy settings over.
+term_message cb "\nSetting up preferences..."
+
+task_start "Copying preferences"
 sudo cp configs/com.apple.dock.plist ~/Library/Preferences
 sudo cp configs/com.apple.EmojiPreferences.plist ~/Library/Preferences
+task_done "Preferences copied"
+
+task_start "Copying ZSH config"
 sudo cp configs/.zshrc ~/
+task_end "ZSH config copied"
+
+term_message cb "\nInstalling lockscreen."
+desktop_pictures_dir='/Library/Caches/Desktop Pictures'
+
+  task_start "Getting User UUID"
+  uuidWithFieldName=$(dscl . -read "/Users/$USER" GeneratedUID)
+  uuid=${uuidWithFieldName#'GeneratedUID: '}
+  task_done "User UUID retrieved"
+  # echo $uuid
+
+  task_start "Checking for desktop pictures directories."
+
+  # check if the /Library/Caches/Desktop Pictures directory exists
+  if [ -d "$desktop_pictures_dir/" ]; then
+
+      # check if there's a subfolder with the user's UUID
+      if [ -d "$desktop_pictures_dir/$uuid/" ]; then
+        task_done "Desktop pictures directories confirmed."
+        task_start ""
+
+        # check if a lockscreen.png already exists
+        if [ -f "$desktop_pictures_dir/$uuid/lockscreen.png" ]; then
+            task_fail "Lockscreen image already exists in $desktop_pictures_dir/$uuid. Skipping copy."
+          else
+
+            # check if repo has lockscreen to copy
+            if [ -f ./configs/lockscreen.png ]; then
+              cp "./configs/lockscreen.png" "$desktop_pictures_dir/$uuid/"
+              task_done "Lockscreen image copied into $desktop_pictures_dir/$uuid."
+            else
+              task_fail "./configs/ does not have a lockscreen image to copy."
+            fi
+        fi
+      else
+        task_fail "Desktop pictures directory for $uuid does not exist."
+      fi
+  else
+      task_fail "Error: /Library/Caches/Desktop Pictures/ directory does not exist."
+  fi
+
+  term_message gb "\nPreferences configuration completed."
+
+

--- a/mas.sh
+++ b/mas.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# import util functions
+[ -f ./utils.sh ] && . ./utils.sh
+
 # Mac App Store apps have IDs. You can find these
 # with `mas search <name>`.
 
@@ -12,6 +15,10 @@ apps=(
   1440405750 # MusicHarbor: https://apps.apple.com/us/app/musicharbor-track-new-music/id1440405750
 )
 
+task_start "Installing apps from the Mac App Store."
+
 for app in "${apps[@]}"; do
     mas install $app
 done
+
+task_done "Mac apps installed"

--- a/start-here.sh
+++ b/start-here.sh
@@ -1,67 +1,11 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # run with sudo sh {script location}
 
-# Function to set terminal colors if supported.
-term_colors() {
-    if [[ -t 1 ]]; then
-        RED=$(printf '\033[31m')
-        GREEN=$(printf '\033[32m')
-        YELLOW=$(printf '\033[33m')
-        BLUE=$(printf '\033[34m')
-        MAGENTA=$(printf '\033[35m')
-        CYAN=$(printf '\033[36m')
-        BOLD=$(printf '\033[1m')
-        RESET=$(printf '\033[0m')
-    else
-        RED=""
-        GREEN=""
-        YELLOW=""
-        BLUE=""
-        MAGENTA=""
-        CYAN=""
-        BOLD=""
-        RESET=""
-    fi
-}
+set -o errexit
+set -o pipefail
 
-# Function to output colored or bold terminal messages.
-# Usage examples: term_message "This is a default color and style message"
-#                 term_message nb "This is a default color bold message"
-#                 term_message rb "This is a red bold message"
-term_message() {
-    local set_color=""
-    local set_style=""
-    [[ -z "${2}" ]] && echo -ne "${1}" >&2 && return
-    [[ ${1:0:1} == "d" ]] && set_color=${RESET}
-    [[ ${1:0:1} == "r" ]] && set_color=${RED}
-    [[ ${1:0:1} == "g" ]] && set_color=${GREEN}
-    [[ ${1:0:1} == "y" ]] && set_color=${YELLOW}
-    [[ ${1:0:1} == "b" ]] && set_color=${BLUE}
-    [[ ${1:0:1} == "m" ]] && set_color=${MAGENTA}
-    [[ ${1:0:1} == "c" ]] && set_color=${CYAN}
-    [[ ${1:1:2} == "b" ]] && set_style=${BOLD}
-    echo "${set_color}${set_style}${2}${RESET}" >&2 && return
-}
-
-# Displays a box containing a dash and message
-task_start() {
-    echo "[-] ${1}"
-}
-
-# Displays a box containing a green tick and optional message if required.
-task_done() {
-    echo "\r[\033[0;32m\xE2\x9C\x94\033[0m] ${1}"
-}
-
-# Displays a box containing a red cross and optional message if required.
-task_fail() {
-    echo "\r[\033[0;31m\xe2\x9c\x98\033[0m] ${1}"
-}
-
-# Function check command exists
-command_exists() {
-    command -v "${@}" >/dev/null 2>&1
-}
+# import util functions
+[ -f ./utils.sh ] && . ./utils.sh
 
 install_homebrew() {
     term_message cb "\nInstalling Homebrew..."
@@ -93,50 +37,50 @@ install_homebrew() {
 }
 
 install_git() {
-  term_message cb "\nInstalling git formulae..."
-  task_start "Checking brew for git"
-  if brew list "git" >/dev/null 2>&1 || command_exists "git"; then
-      task_done "Git already installed.$(tput el)"
-  else
-      task_fail "\n"
-      term_message mb "Attempting to install git..."
-      if brew install "git"; then
-          task_done "Git installed.\n"
-      else
-          task_fail "Git install failed.\n"
-      fi
-  fi
+    term_message cb "\nInstalling git formulae..."
+    task_start "Checking brew for git"
+    if brew list "git" >/dev/null 2>&1 || command_exists "git"; then
+        task_done "Git already installed.$(tput el)"
+    else
+        task_fail "\n"
+        term_message mb "Attempting to install git..."
+        if brew install "git"; then
+            task_done "Git installed.\n"
+        else
+            task_fail "Git install failed.\n"
+        fi
+    fi
 }
 
 check_for_repositories_dir() {
-  term_message cb "\nChecking for ~/Repositories directory"
-  task_start "Checking ~/Repositories"
-  if [ ! -d "$HOME/Repositories" ]
-  then
-      task_fail "Error: ~/Repositories does not yet exist. Creating the directory now."
-      task_start "Creating ~/Repositories directory"
-      cd $HOME
-      mkdir Repositories
-      task_done "~/Repositories has been created"
-  else
-    task_done "~/Repositories already exists. Skipping mkdir."
-  fi
+    term_message cb "\nChecking for ~/Repositories directory"
+    task_start "Checking ~/Repositories"
+    if [ ! -d "$HOME/Repositories" ]
+    then
+        task_fail "Error: ~/Repositories does not yet exist. Creating the directory now."
+        task_start "Creating ~/Repositories directory"
+        cd $HOME
+        mkdir Repositories
+        task_done "~/Repositories has been created"
+    else
+        task_done "~/Repositories already exists. Skipping mkdir."
+    fi
 
-  task_start "Switching directories"
-  cd "$HOME/Repositories"
-  task_done "Switched directory"
+    task_start "Switching directories"
+    cd "$HOME/Repositories"
+    task_done "Switched directory"
 }
 
 clone_dotfiles_repo() {
-  term_message cb "\nCloning dotfiles repository"
+    term_message cb "\nCloning dotfiles repository"
 
-  task_start "Cloning dotfiles repository"
-  git clone https://github.com/justaddcl/dotfiles.git
-  task_done "Repository cloned"
+    task_start "Cloning dotfiles repository"
+    # git clone https://github.com/justaddcl/dotfiles.git
+    task_done "Repository cloned"
 
-  task_start "Running system-brew script"
-  sudo sh ./system-brew.sh
-  task_done "Script run"
+    task_start "Running system-brew script"
+    # ./system-brew.sh
+    task_done "Script run"
 }
 
 # The function that does everything
@@ -147,6 +91,7 @@ main() {
     install_git
     check_for_repositories_dir
     clone_dotfiles_repo
+    term_message gb "\nScript completed."
 }
 
 main "${@}"

--- a/system-brew.sh
+++ b/system-brew.sh
@@ -1,9 +1,14 @@
 #!/usr/bin/env bash
 
+# import util functions
+[ -f ./utils.sh ] && . ./utils.sh
+
 function brewSystem() {
+  term_message cb "\nBrewing a new system."
   ./brew.sh;
   ./mas.sh;
   ./install-configs.sh
+  term_message gb "\nSystem brew has completed."
 }
 
 read -p "This will install Homebrew and associated formulae, cask and some apps, plus some MAS apps. Ready? (y/n) " -n 1;

--- a/utils.sh
+++ b/utils.sh
@@ -1,0 +1,79 @@
+# Function to set terminal colors if supported.
+term_colors() {
+    if [[ -t 1 ]]; then
+        RED=$(printf '\033[31m')
+        GREEN=$(printf '\033[32m')
+        YELLOW=$(printf '\033[33m')
+        BLUE=$(printf '\033[34m')
+        MAGENTA=$(printf '\033[35m')
+        CYAN=$(printf '\033[36m')
+        BOLD=$(printf '\033[1m')
+        RESET=$(printf '\033[0m')
+    else
+        RED=""
+        GREEN=""
+        YELLOW=""
+        BLUE=""
+        MAGENTA=""
+        CYAN=""
+        BOLD=""
+        RESET=""
+    fi
+}
+
+# Function to output colored or bold terminal messages.
+# Usage examples: term_message "This is a default color and style message"
+#                 term_message nb "This is a default color bold message"
+#                 term_message rb "This is a red bold message"
+term_message() {
+    local set_color=""
+    local set_style=""
+    [[ -z "${2}" ]] && echo -ne "${1}" >&2 && return
+    [[ ${1:0:1} == "d" ]] && set_color=${RESET}
+    [[ ${1:0:1} == "r" ]] && set_color=${RED}
+    [[ ${1:0:1} == "g" ]] && set_color=${GREEN}
+    [[ ${1:0:1} == "y" ]] && set_color=${YELLOW}
+    [[ ${1:0:1} == "b" ]] && set_color=${BLUE}
+    [[ ${1:0:1} == "m" ]] && set_color=${MAGENTA}
+    [[ ${1:0:1} == "c" ]] && set_color=${CYAN}
+    [[ ${1:1:2} == "b" ]] && set_style=${BOLD}
+    echo -e "${set_color}${set_style}${2}${RESET}" >&2 && return
+}
+
+# Displays a box containing a dash and message
+task_start() {
+    echo -ne "[-] ${1}"
+}
+
+# Displays a box containing a green tick and optional message if required.
+task_done() {
+    echo -e "\r[\033[0;32m\xE2\x9C\x94\033[0m] ${1}"
+}
+
+# Displays a box containing a red cross and optional message if required.
+task_fail() {
+    echo -e "\r[\033[0;31m\xe2\x9c\x98\033[0m] ${1}"
+}
+
+# Function to pause script and check if the user wishes to continue.
+check_continue() {
+    local response
+    while true; do
+        read -r -p "Do you wish to continue (y/N)? " response
+        case "${response}" in
+        [yY][eE][sS] | [yY])
+            echo
+            break
+            ;;
+        *)
+            echo
+            exit
+            ;;
+        esac
+    done
+}
+
+# Function check command exists
+command_exists() {
+    command -v "${@}" >/dev/null 2>&1
+}


### PR DESCRIPTION
## Background
I have a custom lock/login screen which can be installed via an automation.

To do this, the user's UUID must be retrieved to know which folder the lockscreen image should be installed in. Then we can copy the locksceen image from the repo to the correct location.

## What's changed
- Added the lockscreen install to the `install-configs` script
- Refactored the util functions into a separate file to allow reuse
- Updates current scripts to use the util functions and add more log messages