### PR TITLE
Lockscreen download fix

### DIFF
--- a/system-brew.sh
+++ b/system-brew.sh
@@ -273,7 +273,7 @@ install_lockscreen_image() {
 
           # check if repo has lockscreen to copy
           if [ -f ./configs/lockscreen.png ]; then
-            cp "./configs/lockscreen.png" "$desktop_pictures_dir/$uuid/"
+            curl -o $desktop_pictures_dir/$uuid/ 'https://github.com/justaddcl/dotfiles/blob/main/configs/lockscreen.png?raw=true'
             task_done "Lockscreen image copied into $desktop_pictures_dir/$uuid.\n"
           else
             task_fail "./configs/ does not have a lockscreen image to copy. \n"


### PR DESCRIPTION
## Background
The `system-brew` script still attempts to install the lockscreen background image by copying the image from a relative directory and wasn't updated in #8. This PR updates the copy to a download

## What's changed
- Updated the `install_lockscreen_image` function to download the image from GitHub instead of copying a local file