### PR TITLE
Gifski fix

### DIFF
--- a/system-brew.sh
+++ b/system-brew.sh
@@ -332,6 +332,7 @@ formulae_list=(
     curl
     eslint
     gh
+    gifski
     git
     mas
     node
@@ -361,7 +362,6 @@ cask_list=(
     firefox
     fliqlo
     flux
-    gifski
     google-chrome
     font-inconsolata-for-powerline
     font-jetbrains-mono


### PR DESCRIPTION
## Background
There is no cask for `gifski` since it's actually a `formulae`. This PR moves `gifski` from the `cask_list` to the `formulae_list`.

## What's change
- Updated `formulae_list` to include `gifski`, removing it from `cask_list`