### PR TITLE
Neovim fix

### DIFF
--- a/system-brew.sh
+++ b/system-brew.sh
@@ -225,7 +225,7 @@ install_zsh() {
 }
 
 install_mas() {
-  task_message cb "\nInstalling Mac App Store apps..."
+  term_message cb "\nInstalling Mac App Store apps..."
   # Mac App Store apps have IDs. You can find these
   # with `mas search <name>`.
 
@@ -334,6 +334,7 @@ formulae_list=(
     gh
     git
     mas
+    neovim
     node
     nvm
     prettier
@@ -366,7 +367,6 @@ cask_list=(
     font-inconsolata-for-powerline
     font-jetbrains-mono
     kap
-    neovim
     notion
     paragon-ntfs
     numi


### PR DESCRIPTION
## Background
There is no cask for `neovim` since it's actually a `formulae`. This PR moves `neovim` from the `cask_list` to the `formulae_list` as well as fix a typo that was supposed to be `term_message`

## What's change
- Updated `formulae_list` to include `neovim`, removing it from `cask_list`
- Fixes a typo from `task_message` to `term_message`