### PR TITLE
Fix already installed text color

### DIFF
--- a/system-brew.sh
+++ b/system-brew.sh
@@ -103,6 +103,7 @@ Description:    Automate the installation of macOS
                 Fork of autobrew.sh by Mark Bradley
 Author:         JustAddCl
 Requirements:   Command Line Tools (CLT) for Xcode
+
 EOF
 }
 
@@ -331,7 +332,7 @@ print_success() {
 }
 
 print_already_installed() {
-    term_message gb "\n${#already_installed_list[@]} items were already installed and were skipped"
+    term_message bb "\n${#already_installed_list[@]} items were already installed and were skipped"
     for already_installed in ${already_installed_list[@]}; do
         task_start $already_installed
     done

--- a/system-brew.sh
+++ b/system-brew.sh
@@ -332,7 +332,7 @@ print_success() {
 }
 
 print_already_installed() {
-    term_message bb "\n${#already_installed_list[@]} items were already installed and were skipped"
+    term_message bb "\n${#already_installed_list[@]} items were already installed"
     for already_installed in ${already_installed_list[@]}; do
         task_start $already_installed
     done


### PR DESCRIPTION
## Background
The "{#} items were already installed" message prints in green which matches the successfully installed message. This PR is to change the color to blue to help differentiate the messages.

## What's changed
- Updated the `print_already_installed` `term_message` to blue
- Updated the copy to just "${#} items were already installed"