### PR TITLE
Add install mas error handling

### DIFF
--- a/system-brew.sh
+++ b/system-brew.sh
@@ -255,9 +255,13 @@ install_mas() {
                 error_list+=(${app})
             else
                 task_start "Installing ${app}"
-                mas install $app
-                task_done "App ID: ${app} installed"
-                installed_list+=(${app})
+                if mas install $app; then
+                    task_done "App ID: ${app} installed"
+                    installed_list+=(${app})
+                else
+                    task_fail "App ID: ${app} install failed"
+                    error_list+=(${cask})
+                fi
             fi
         fi
     done


### PR DESCRIPTION
## Background
The install mas step seems to run into the `500 Internal Server Error` but not for the same attempted app install then the script ends. This PR is to add some error handling for the `mas` installs so that if an install fails, the script can continue.

Fixes #13 

## What's changed
- Updated the `install_mas` function to handle install errors