### PR TITLE
Syntax error fix

### DIFF
--- a/system-brew.sh
+++ b/system-brew.sh
@@ -293,7 +293,7 @@ install_configs() {
         mkdir "${raycast_dir}"
     fi
     curl -o ${raycast_dir} 'https://raw.githubusercontent.com/justaddcl/dotfiles/main/configs/2023-04-07.rayconfig'
-    task_done "Downloaded Raycast config
+    task_done "Downloaded Raycast config"
 }
 
 install_walls() {


### PR DESCRIPTION
## Background
A typo (a missing quotation mark) was causing a syntax error. This PR is to fix that.

## What's changed
- Fixed a typo in `install_configs` function