### PR TITLE
Add version to script info

### DIFF
--- a/system-brew.sh
+++ b/system-brew.sh
@@ -98,6 +98,7 @@ script_info() {
     cat <<EOF
 
 Name:           system-brew.sh
+Version:        v1.0.21
 Description:    Automate the installation of macOS
                 applications and packages using homebrew.
                 Fork of autobrew.sh by Mark Bradley


### PR DESCRIPTION
## Background
When running the script via `curl`, it can be hard to tell the latest version of the script is running. This PR adds the version number to the `script_info` to address this.

## What's changed
- Updated `script_info` to print version number