### PR TITLE
fix: updates Hidden Bar app mas ID

### DIFF
--- a/system-brew.sh
+++ b/system-brew.sh
@@ -249,7 +249,7 @@ install_mas() {
         937984704  # Amphetamine: https://apps.apple.com/us/app/amphetamine/id937984704?mt=12
         1643751440 # Energiza https://apps.apple.com/us/app/energiza-battery-monitor/id1643751440?mt=12
         1423210932 # Flow - Focus & Pomodoro Timer: https://flowapp.info/
-        1452452150 # Hidden Bar https://apps.apple.com/us/developer/dwarves-foundation/id1452452150
+        1452453066 # Hidden Bar https://apps.apple.com/us/app/hidden-bar/id1452453066?mt=12
         1440405750 # MusicHarbor: https://apps.apple.com/us/app/musicharbor-track-new-music/id1440405750
     )
 
@@ -384,7 +384,7 @@ install_walls() {
 
 install_lockscreen_image() {
     term_message cb "\nInstalling lockscreen..."
-    desktop_pictures_dir="/Library/Caches/Desktop\ Pictures"
+    desktop_pictures_dir="/Library/Caches/Desktop Pictures"
 
     task_start "Getting User UUID..."
     uuidWithFieldName=$(dscl . -read "/Users/$USER" GeneratedUID)


### PR DESCRIPTION
## Background
The app ID for [Hidden Bar](https://apps.apple.com/us/app/hidden-bar/id1452453066?mt=12) seems to have been updated since I first created the script. This PR updates the app ID used by the script to install the application.