### PR TITLE
Run ZSH install in unattended mode

### DIFF
--- a/configs/.zshrc
+++ b/configs/.zshrc
@@ -1,20 +1,18 @@
-# Fig pre block. Keep at the top of this file.
-[[ -f "$HOME/.fig/shell/zshrc.pre.zsh" ]] && builtin source "$HOME/.fig/shell/zshrc.pre.zsh"
 # If you come from bash you might have to change your $PATH.
 export PATH=$HOME/bin:/usr/local/bin:$PATH
 
 # Path to your oh-my-zsh installation.
-export ZSH="/Users/yuji/.oh-my-zsh"
+export ZSH="$HOME/.oh-my-zsh"
 
 export NVM_DIR="$HOME/.nvm"
-[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
-[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"                   # This loads nvm
+[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion" # This loads nvm bash_completion
 
 # Set name of the theme to load --- if set to "random", it will
 # load a random theme each time oh-my-zsh is loaded, in which case,
 # to know which specific one was loaded, run: echo $RANDOM_THEME
 # See https://github.com/ohmyzsh/ohmyzsh/wiki/Themes
-ZSH_THEME="cobalt2"
+ZSH_THEME="cerulean"
 
 # Set list of themes to pick from when loading at random
 # Setting this variable when ZSH_THEME=random will cause zsh to load
@@ -76,19 +74,9 @@ ZSH_THEME="cobalt2"
 # Add wisely, as too many plugins slow down shell startup.
 
 plugins=(
-  appup
-  copypath
-  docker
-  docker-compose
-  gatsby
   git
-  heroku
-  history
   jsontools
-  macos
-  npm
   sudo
-  vscode
   zsh-autosuggestions
   zsh-syntax-highlighting
 )
@@ -118,16 +106,66 @@ source $ZSH/oh-my-zsh.sh
 # For a full list of active aliases, run `alias`.
 #
 # aliases
-alias zsh-config="code ~/.zshrc"
-alias zsh-reload="source ~/.zshrc"
+
+# ZSH configs aliases
+alias zsh-config="code $HOME/.zshrc"
+alias zsh-reload="source $HOME/.zshrc"
+
+# VSCode aliases
+alias vscode-ext="open $HOME/.vscode/extensions"
+
+# Postgres aliases
 alias pg-start="pg_ctl -D /usr/local/var/postgresql@11 start"
 alias pg-stop="pg_ctl -D /usr/local/var/postgresql@11 stop"
 alias pg-restart="pg_ctl -D /usr/local/var/postgresql@11 restart"
-alias vscode-ext="open ~/.vscode/extensions"
-#alias capScrn="node /Users/yujinelson/Repositories/Magpul-m2/scripts/visual-testing.js"
+
+# Teya development aliases
+export CSP_BFF_DIR="$HOME/Repos/backoffice-bff"
+export CSP_WEB_DIR="$HOME/Repos/global-backoffice-web"
+export WEB_PLAT_DIR="$HOME/Repos/salt-web-platform"
+
+alias cd-bff="cd $CSP_BFF_DIR"
+alias bff-code="cd-bff && vsc"
+alias bff-dev="cd-bff && yarn dev"
+
+alias cd-csp="cd $CSP_WEB_DIR"
+alias csp-code="cd-csp && vsc"
+alias csp-dev="cd-csp && yarn dev"
+
+alias cd-plat="cd $WEB_PLAT_DIR"
+alias plat-code="cd-plat && vsc"
+
+alias infra-provisioning-dashboard="$HOME//Repos/sp-dashboard"
+
+#alias capScrn="node $HOME/Repositories/Magpul-m2/scripts/visual-testing.js"
 #alias ohmyzsh="code ~/.oh-my-zsh"
+
+# Make sure .nvmrc files are honoured when you cd into a folder
+# export NVM_DIR=~/.nvm
+# source $(brew --prefix nvm)/nvm.sh
+# autoload -U add-zsh-hook
+# load-nvmrc() {
+#   local nvmrc_path
+#   nvmrc_path="$(nvm_find_nvmrc)"
+
+#   if [ -n "$nvmrc_path" ]; then
+#     local nvmrc_node_version
+#     nvmrc_node_version=$(nvm version "$(cat "${nvmrc_path}")")
+
+#     if [ "$nvmrc_node_version" = "N/A" ]; then
+#       nvm install
+#     elif [ "$nvmrc_node_version" != "$(nvm version)" ]; then
+#       nvm use
+#     fi
+#   elif [ -n "$(PWD=$OLDPWD nvm_find_nvmrc)" ] && [ "$(nvm version)" != "$(nvm version default)" ]; then
+#     echo "Reverting to nvm default version"
+#     nvm use default
+#   fi
+# }
+# add-zsh-hook chpwd load-nvmrc
+# load-nvmrc
 
 # include z
 # . /usr/local/etc/profile.d/z.sh
 export PATH="/usr/local/opt/postgresql@11/bin:$PATH"
-source /Users/yuji/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
+source $HOME/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh

--- a/configs/cerulean.zsh-theme
+++ b/configs/cerulean.zsh-theme
@@ -1,0 +1,112 @@
+#
+# Cerulean theme
+# This theme is based off of Wes Bos' Cobalt2 Theme with minor adjustments
+# https://github.com/wesbos/Cobalt2-iterm
+#
+# # README
+#
+# In order for this theme to render correctly, you will need a
+# [Powerline-patched font](https://gist.github.com/1595572).
+##
+### Segment drawing
+# A few utility functions to make it easy and re-usable to draw segmented prompts
+
+CURRENT_BG='NONE'
+SEGMENT_SEPARATOR=''
+
+# Begin a segment
+# Takes two arguments, background and foreground. Both can be omitted,
+# rendering default background/foreground.
+prompt_segment() {
+  local bg fg
+  [[ -n $1 ]] && bg="%K{$1}" || bg="%k"
+  [[ -n $2 ]] && fg="%F{$2}" || fg="%f"
+  if [[ $CURRENT_BG != 'NONE' && $1 != $CURRENT_BG ]]; then
+    echo -n " %{$bg%F{$CURRENT_BG}%}$SEGMENT_SEPARATOR%{$fg%} "
+  else
+    echo -n "%{$bg%}%{$fg%} "
+    # echo $(pwd | sed -e "s,^$HOME,~," | sed "s@\(.\)[^/]*/@\1/@g")
+    # echo $(pwd | sed -e "s,^$HOME,~,")
+  fi
+  CURRENT_BG=$1
+  [[ -n $3 ]] && echo -n $3
+}
+
+# End the prompt, closing any open segments
+prompt_end() {
+  if [[ -n $CURRENT_BG ]]; then
+    echo -n " %{%k%F{$CURRENT_BG}%}$SEGMENT_SEPARATOR"
+  else
+    echo -n "%{%k%}"
+  fi
+  echo -n "%{%f%}"
+  CURRENT_BG=''
+}
+
+### Prompt components
+# Each component will draw itself, and hide itself if no information needs to be shown
+
+# Context: user@hostname (who am I and where am I)
+prompt_context() {
+  local user=$(whoami)
+
+  if [[ "$user" != "$DEFAULT_USER" || -n "$SSH_CLIENT" ]]; then
+    #prompt_segment magenta default "%(!.%{%F{yellow}%}.)>"
+    prompt_segment black green "%(!.%{%F{yellow}%}.)>"
+    # echo -n "%(!.%{%F{yellow}%}.)%{$fg[green]%}>%f "
+  fi
+}
+
+# Git: branch/detached head, dirty status
+prompt_git() {
+  local ref dirty
+  if $(git rev-parse --is-inside-work-tree >/dev/null 2>&1); then
+    ZSH_THEME_GIT_PROMPT_DIRTY='±'
+    dirty=$(parse_git_dirty)
+    ref=$(git symbolic-ref HEAD 2>/dev/null) || ref="➦ $(git show-ref --head -s --abbrev | head -n1 2>/dev/null)"
+    if [[ -n $dirty ]]; then
+      prompt_segment yellow black
+    else
+      prompt_segment green black
+    fi
+    echo -n "${ref/refs\/heads\// }$dirty"
+  fi
+}
+
+# Dir: current working directory
+prompt_dir() {
+  prompt_segment blue black '%0~'
+  # prompt_segment blue black "…${PWD: -30}"
+}
+
+# Status:
+# - was there an error
+# - am I root
+# - are there background jobs?
+prompt_status() {
+  local symbols
+  symbols=()
+  [[ $RETVAL -ne 0 ]] && symbols+="%{%F{red}%}✘"
+  [[ $UID -eq 0 ]] && symbols+="%{%F{yellow}%}⚡"
+  [[ $(jobs -l | wc -l) -gt 0 ]] && symbols+="%{%F{cyan}%}⚙"
+
+  [[ -n "$symbols" ]] && prompt_segment black default "$symbols"
+}
+
+# current time with milliseconds
+current_time() {
+  prompt_segment lightBlack default "%*"
+}
+
+## Main prompt
+build_prompt() {
+  RETVAL=$?
+  prompt_status
+  prompt_context
+  prompt_dir
+  prompt_git
+  prompt_end
+}
+
+PROMPT='%{%f%b%k%}$(build_prompt) '
+RPROMPT=' %*'

--- a/system-brew.sh
+++ b/system-brew.sh
@@ -230,7 +230,7 @@ brew_cleanup() {
 install_zsh() {
     if ! which "zsh" >/dev/null 2>&1; then
         task_start "Installing ZSH..."
-        sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+        sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
         task_done "ZSH installed.\n"
         success_list+=('ZSH')
     else

--- a/system-brew.sh
+++ b/system-brew.sh
@@ -292,6 +292,11 @@ install_configs() {
         task_done "Installed emoji preferences at 'https://github.com/justaddcl/dotfiles/raw/main/configs/com.apple.dock.plist'"
         installed_list+=("Emoji preferences")
 
+        task_start "Downloading ZSH Cerulean theme..."
+        curl -o $HOME/.oh-my-zsh/themes/cerulean.zsh-theme 'https://raw.githubusercontent.com/justaddcl/dotfiles/main/configs/cerulean.zsh-theme'
+        task_done "Installed ZSH Cerulean theme"
+        installed_list+=("ZSH cerulean theme")
+
         task_start "Downloading ZSH config..."
         curl -o $HOME/.zshrc 'https://raw.githubusercontent.com/justaddcl/dotfiles/main/configs/.zshrc'
         task_done "Installed ZSH config"


### PR DESCRIPTION
## Background
After the ZSH install script runs, it tries to change the default shell and also runs zsh when the installation has finished. This causes the script to get stuck in the zsh sub-shell and will never run the rest of the `system-brew` script. This PR fixes the issue by [passing the `--unattended` flag](https://github.com/ohmyzsh/ohmyzsh#unattended-install).

Bonus:
This PR updates the ZSH config and also installs the cerulean theme.

Fixes #20

## What's changed
- Updated `install_zsh` to install zsh with the `--unattended` flag
- Updated `install_configs` to download and install the cerulean zsh theme
- Added the cerulean ZSH theme file
- Updated `configs/.zshrc`