### PR TITLE
Add Itsycal, Shottr, and CLI tools to homebrew list

### DIFF
--- a/system-brew.sh
+++ b/system-brew.sh
@@ -507,9 +507,10 @@ cask_list=(
     firefox
     fliqlo
     flux
-    google-chrome
     font-inconsolata-for-powerline
     font-jetbrains-mono
+    google-chrome
+    itsycal
     kap
     notion
     paragon-ntfs

--- a/system-brew.sh
+++ b/system-brew.sh
@@ -474,9 +474,11 @@ formulae_list=(
     bat-extras
     curl
     eslint
+    fzf
     gh
     gifski
     git
+    jq
     mas
     neovim
     node
@@ -488,6 +490,7 @@ formulae_list=(
     unzip
     wget
     yarn
+    zoxide
 )
 
 cask_list=(

--- a/system-brew.sh
+++ b/system-brew.sh
@@ -519,6 +519,7 @@ cask_list=(
     raycast
     rectangle
     rocket
+    shottr
     signal
     spotify
     steam


### PR DESCRIPTION
## Background
A few more apps and tools have been added via homebrew
- [fzf](https://github.com/junegunn/fzf)
- [jq](https://jqlang.github.io/jq/)
- [zoxide](https://github.com/ajeetdsouza/zoxide)
- [itsycal](https://www.mowglii.com/itsycal/)
- [shottr](https://shottr.cc/)

## What's changed
- Updated the `formulae_list` and `cask_list` with the apps/tools listed above