### PR TITLE
Add git-delta homebrew formulae

### DIFF
--- a/system-brew.sh
+++ b/system-brew.sh
@@ -478,6 +478,7 @@ formulae_list=(
     gh
     gifski
     git
+    git-delta
     jq
     mas
     neovim


### PR DESCRIPTION
## Background
This adds the `git-delta` package for improved syntax and diff highlighting with `batdiff`

## What's changed
- Updated the `formulae_list` to include `git-delta`