### PR TITLE
Run Homebrew installer in non-interactive mode

### DIFF
--- a/system-brew.sh
+++ b/system-brew.sh
@@ -146,7 +146,7 @@ install_homebrew() {
     else
         task_fail "\n"
         term_message mb "Attempting to install Homebrew..."
-        if /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"; then
+        if NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"; then
             task_done "Homebrew installed.\n"
         else
             task_fail "Homebrew install failed.\n"


### PR DESCRIPTION
## Background
If homebrew isn't already installed, pretty much the whole script won't run since most is through homebrew. (As reported in #18). This PR is to update the installer to run in non-interactive mode which hopefully will fix this issue.

Fixes #18 

## What's changed
- Updated `install_homebrew` to run the installer in non-interactive mode