### PR TITLE
System brew clean up

### DIFF
--- a/system-brew.sh
+++ b/system-brew.sh
@@ -278,20 +278,11 @@ install_mas() {
 }
 
 install_configs() {
-    term_message cb "\nSetting up preferences..."
+    raycast_dir="${HOME}/Documents/Raycast"
+    term_message cb "\nSetting up configs..."
     local response
     read -r -p "There may already be configs in ${HOME}/Library/Preferences/, ${HOME}/.zshrc, and in ${raycast_dir} and continuing may overwrite those files. Do you want to continue? (y/n) " response
     if [[ ${response,,} =~ ^(y|yes)$ ]]; then
-        # task_start "Downloading dock preferences"
-        # curl -o $HOME/Library/Preferences/com.apple.dock.plist 'https://github.com/justaddcl/dotfiles/raw/main/configs/com.apple.dock.plist'
-        # task_done "Installed dock preferences at 'https://github.com/justaddcl/dotfiles/raw/main/configs/com.apple.dock.plist'"
-        # installed_list+=("Dock preferences")
-
-        # task_start "Downloading emoji preferences"
-        # curl -o $HOME/Library/Preferences/com.apple.EmojiPreferences.plist 'https://github.com/justaddcl/dotfiles/raw/main/configs/com.apple.EmojiPreferences.plist'
-        # task_done "Installed emoji preferences at 'https://github.com/justaddcl/dotfiles/raw/main/configs/com.apple.dock.plist'"
-        # installed_list+=("Emoji preferences")
-
         task_start "Downloading ZSH Cerulean theme..."
         curl -o $HOME/.oh-my-zsh/themes/cerulean.zsh-theme 'https://raw.githubusercontent.com/justaddcl/dotfiles/main/configs/cerulean.zsh-theme'
         task_done "Installed ZSH Cerulean theme"
@@ -303,7 +294,6 @@ install_configs() {
         installed_list+=("ZSH config")
 
         task_start "Downloading Raycast config..."
-        raycast_dir="${HOME}/Documents/Raycast"
         if [ ! -d "${raycast_dir}" ]; then
             mkdir "${raycast_dir}"
         fi

--- a/system-brew.sh
+++ b/system-brew.sh
@@ -99,7 +99,7 @@ script_info() {
     cat <<EOF
 
 Name:           system-brew.sh
-Version:        v1.0.27
+Version:        v1.0.33
 Description:    Automate the installation of macOS
                 applications and packages using homebrew.
                 Fork of autobrew.sh by Mark Bradley

--- a/system-brew.sh
+++ b/system-brew.sh
@@ -465,7 +465,6 @@ handle_exit() {
 }
 
 tap_list=(
-    homebrew/cask-fonts
 )
 
 formulae_list=(


### PR DESCRIPTION
## Background
Updated the `tap_list` to remove empty casks, cleaned up the `install_configs` function, incremented version number

## What's changed
- Removed `homebrew/cask-fonts` from `tap_list`
- Updated `install_configs` print message
- Fixed the `raycast_dir` variable declaration
- Removed the dock and emoji preferences (already commented out) from `install_configs`
- Updated version number