### PR TITLE
Update Gifski to GUI version

### DIFF
--- a/system-brew.sh
+++ b/system-brew.sh
@@ -249,6 +249,7 @@ install_mas() {
         937984704  # Amphetamine: https://apps.apple.com/us/app/amphetamine/id937984704?mt=12
         1643751440 # Energiza https://apps.apple.com/us/app/energiza-battery-monitor/id1643751440?mt=12
         1423210932 # Flow - Focus & Pomodoro Timer: https://flowapp.info/
+        1351639930 # Gifski https://gif.ski/
         1452453066 # Hidden Bar https://apps.apple.com/us/app/hidden-bar/id1452453066?mt=12
         1440405750 # MusicHarbor: https://apps.apple.com/us/app/musicharbor-track-new-music/id1440405750
     )
@@ -465,7 +466,6 @@ formulae_list=(
     eslint
     fzf
     gh
-    gifski
     git
     git-delta
     jq


### PR DESCRIPTION
## Background
- `gifski` is currently being installed as a CLI, but I've only used the GUI version. This PR is to update which version of `gifski` is installed.

## What's changed
- Added the `gifski` Mac app store ID to the `mas` install list
- Removed `gifski` from the homebrew formulae list