### PR TITLE
Update ZSH set up

### DIFF
--- a/configs/.zshrc
+++ b/configs/.zshrc
@@ -77,8 +77,6 @@ plugins=(
   git
   jsontools
   sudo
-  zsh-autosuggestions
-  zsh-syntax-highlighting
 )
 
 source $ZSH/oh-my-zsh.sh

--- a/configs/.zshrc
+++ b/configs/.zshrc
@@ -112,11 +112,6 @@ alias zsh-reload="source $HOME/.zshrc"
 # VSCode aliases
 alias vscode-ext="open $HOME/.vscode/extensions"
 
-# Postgres aliases
-alias pg-start="pg_ctl -D /usr/local/var/postgresql@11 start"
-alias pg-stop="pg_ctl -D /usr/local/var/postgresql@11 stop"
-alias pg-restart="pg_ctl -D /usr/local/var/postgresql@11 restart"
-
 # use `delta` by default to display diffs
 export BATDIFF_USE_DELTA=true
 

--- a/system-brew.sh
+++ b/system-brew.sh
@@ -281,6 +281,19 @@ install_mas() {
 install_configs() {
     raycast_dir="${HOME}/Documents/Raycast"
     term_message cb "\nSetting up configs..."
+
+    # enable zsh-autosuggestions
+    echo "source $(brew --prefix)/share/zsh-autosuggestions/zsh-autosuggestions.zsh" >>${ZDOTDIR:-$HOME}/.zshrc
+
+    # enable zsh-syntax-highlighting
+    echo "source $(brew --prefix)/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh" >>${ZDOTDIR:-$HOME}/.zshrc
+
+    # set up fzf key bindings and fuzzy completion
+    echo "source <(fzf --zsh)" >>${ZDOTDIR:-$HOME}/.zshrc
+
+    # set up zoxide to replace default "cd" command
+    echo "eval "$(zoxide init zsh --cmd cd)"" >>${ZDOTDIR:-$HOME}/.zshrc
+
     local response
     read -r -p "There may already be configs in ${HOME}/Library/Preferences/, ${HOME}/.zshrc, and in ${raycast_dir} and continuing may overwrite those files. Do you want to continue? (y/n) " response
     if [[ ${response,,} =~ ^(y|yes)$ ]]; then
@@ -298,7 +311,7 @@ install_configs() {
         if [ ! -d "${raycast_dir}" ]; then
             mkdir "${raycast_dir}"
         fi
-        curl -o ${raycast_dir}/2024-06-06.rayconfig 'https://raw.githubusercontent.com/justaddcl/dotfiles/main/configs/2024-06-06.rayconfig'
+        curl -o ${raycast_dir}/2024-06-06.rayconfig 'https://raw.githubusercontent.com/justaddcl/dotfiles/main/configs/2024-06-06.rayconfig' --create-dirs
         task_done "Downloaded Raycast config"
         installed_list+=("Raycase config")
     else
@@ -480,6 +493,8 @@ formulae_list=(
     unzip
     wget
     yarn
+    zsh-autosuggestions
+    zsh-syntax-highlighting
     zoxide
 )
 


### PR DESCRIPTION
## Background
When running `system-brew` on a new computer, there was still a bunch of manual install and set up required that could be automated via the script. This PR is to install some zsh plugins via homebrew and add the configurations to `.zsh` config file. 

## What's changed
[`system-brew`]
- updated the homebrew formula list to include
  - `zsh-autosuggestions`
  - `zsh-syntax-highlighting`
- updated `install_configs` to add zsh plugin set up to `.zshrc`
- updated the `curl` call for downloading the Raycast config file with the `--create-dirs` flag


[`.zshrc`]
- updated the zsh-plugins list to remove
  - `zsh-autosuggestions`
  - `zsh-syntax-highlighting`
- removed outdated postgres aliases and reference