### PR TITLE
Update NVM install

### DIFF
--- a/system-brew.sh
+++ b/system-brew.sh
@@ -227,6 +227,18 @@ brew_cleanup() {
     fi
 }
 
+install_nvm() {
+    if ! command "-v nvm" >/dev/null 2>&1; then
+        task_start "Installing nvm..."
+        sh -c "$(curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash)"
+        task_done "nvm installed.\n"
+        success_list+=('nvm')
+    else
+        task_start "nvm already installed\n"
+        already_installed_list+=('nvm')
+    fi
+}
+
 install_zsh() {
     if ! which "zsh" >/dev/null 2>&1; then
         task_start "Installing ZSH..."
@@ -485,7 +497,6 @@ formulae_list=(
     mas
     neovim
     node
-    nvm
     prettier
     ripgrep
     tmux
@@ -549,6 +560,7 @@ main() {
     install_homebrew
     brew_packages
     brew_cleanup
+    install_nvm
     install_mas
     install_zsh
     install_configs

--- a/system-brew.sh
+++ b/system-brew.sh
@@ -99,7 +99,7 @@ script_info() {
     cat <<EOF
 
 Name:           system-brew.sh
-Version:        v1.0.33
+Version:        v1.0.34
 Description:    Automate the installation of macOS
                 applications and packages using homebrew.
                 Fork of autobrew.sh by Mark Bradley


### PR DESCRIPTION
## Background
Per the [nvm Homebrew formulae page](https://formulae.brew.sh/formula/nvm), managing nvm via Homebrew is unsupported and doesn't seem to work, so this PR is to switch the install to follow [nvm's official installation instructions](https://formulae.brew.sh/formula/nvm).

## What's changed
- added `install_nvm` function
- updated `main()` to run `install_nvm`
- removed `nvm` from the `formulae_list`
