### PR TITLE
Adds Clipy cask

### DIFF
--- a/system-brew.sh
+++ b/system-brew.sh
@@ -516,6 +516,7 @@ cask_list=(
     arc
     authy
     brave-browser
+    clipy
     coconutbattery
     discord
     disk-inventory-x


### PR DESCRIPTION
## Background
This PR is to add [`clipy`](https://clipy-app.com/) to the homebrew casks list

## What's changed
- Added `clipy` to the `cask_list`